### PR TITLE
minecraft-server: remove out-of-place Type option in backup timer

### DIFF
--- a/minecraft-server/minecraftd-backup.timer
+++ b/minecraft-server/minecraftd-backup.timer
@@ -2,7 +2,6 @@
 Description=Daily Minecraft Server Backup
 
 [Timer]
-Type=forking
 OnCalendar=daily
 AccuracySec=5min
 Persistent=true


### PR DESCRIPTION
Hey @Edenhofer, thanks for maintaining this package!

I caught some warnings in my logs about an unknown option in my `.timer` file for the backup service, looks like this isn't needed (the `Type` is needed in the service definition, not the timer.)

```
Jan 29 23:38:06 xxx systemd[1]: [/usr/lib/systemd/system/minecraftd-backup.timer:5] Unknown lvalue 'Type' in section 'Timer'
```

Thanks!
