### PR TITLE
This change makes the minecraftd.sh script slightly more generic, and allows cuberite to be launched from it.

### DIFF
--- a/cuberite/cuberite.conf
+++ b/cuberite/cuberite.conf
@@ -1,0 +1,22 @@
+# THIS IS THE CONFIGURATION FILE FOR THE MANAGING SCRIPT NOT FOR THE ACTUAL SERVER
+# Variables are interpreted in bash. Simply using bash-syntax is sufficient.
+
+# General parameters
+SERVER_ROOT="/srv/cuberite"
+BACKUP_DEST="/srv/cuberite/backup"
+LOGPATH="/srv/cuberite/logs"
+BACKUP_PATHS="world world_nether world_the_end" # World paths separated by spaces relative to SERVER_ROOT
+KEEP_BACKUPS="10"
+GAME_USER="cuberite"
+SESSION_NAME="cuberite"
+
+# System parameters for java
+EXECUTABLE_CMD="Cuberite"
+# System parameters for the actual game server
+# Describes whether a daemon process which stops the server if it is not used by a player
+# within IDLE_IF_TIME seconds should be started. The GAME_PORT is not inhereted to the server!
+IDLE_SERVER=false         # true or false
+IDLE_SESSION_NAME="idle_server"
+GAME_PORT="25565"         # used to listen for incoming connections when the server is down
+CHECK_PLAYER_TIME="30"    # in seconds
+IDLE_IF_TIME="1200"       # in seconds

--- a/cuberite/cuberite.service
+++ b/cuberite/cuberite.service
@@ -4,7 +4,10 @@ After=local-fs.target network.target
 
 [Service]
 Type=forking
-ExecStart=/srv/cuberite/Cuberite -d
+Environment=NAME=cuberite
+Environment=GAME=cuberite
+ExecStart=/usr/bin/minecraftd.sh start
+ExecStop=/usr/bin/minecraftd.sh stop
 User=cuberite
 Group=cuberite
 

--- a/minecraft-server/minecraftd.sh
+++ b/minecraft-server/minecraftd.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # The actual program name
-declare -r myname="minecraftd"
-declare -r game="minecraft"
+[[ ! -z "${NAME}" ]] && declare -r myname=$NAME || myname="minecraftd"
+[[ ! -z "${GAME}" ]] && declare -r game=$GAME || game="minecraftd"
 
 # General rule for the variable-naming-schema:
 # Variables in capital letters may be passed through the command line others not.
@@ -23,6 +23,7 @@ declare -r game="minecraft"
 [[ ! -z "${MAXHEAP}" ]] && declare -r MAXHEAP=${MAXHEAP} || MAXHEAP="1024M"
 [[ ! -z "${THREADS}" ]] && declare -r THREADS=${THREADS} || THREADS="1"
 [[ ! -z "${JAVA_PARMS}" ]] && declare -r JAVA_PARMS=${JAVA_PARMS} || JAVA_PARMS="-Xmx${MAXHEAP} -Xms${MINHEAP} -XX:ParallelGCThreads=${THREADS}"
+[[ ! -z "${EXECUTABLE_CMD}" ]] && declare -r EXECUTABLE_CMD=${EXECUTABLE_CMD} || EXECUTABLE_CMD="java ${JAVA_PARAMS} -jar '${SERVER_ROOT}/${MAIN_EXECUTABLE}' nogui"
 
 # System parameters for the control script
 [[ ! -z "${IDLE_SERVER}" ]]       && tmp_IDLE_SERVER=${IDLE_SERVER}   || IDLE_SERVER="false"
@@ -154,7 +155,7 @@ server_start() {
 		echo "A screen ${SESSION_NAME} session is already running. Please close it first."
 	else
 		echo -en "Starting server..."
-		${SUDO_CMD} screen -dmS "${SESSION_NAME}" /bin/bash -c "cd '${SERVER_ROOT}'; java ${JAVA_PARMS} -jar '${SERVER_ROOT}/${MAIN_EXECUTABLE}' nogui"
+		${SUDO_CMD} screen -dmS "${SESSION_NAME}" /bin/bash -c "cd '${SERVER_ROOT}'; ${EXECUTABLE_CMD}' nogui"
 		echo -e "\e[39;1m done\e[0m"
 	fi
 

--- a/minecraft-server/minecraftd.sh
+++ b/minecraft-server/minecraftd.sh
@@ -155,7 +155,7 @@ server_start() {
 		echo "A screen ${SESSION_NAME} session is already running. Please close it first."
 	else
 		echo -en "Starting server..."
-		${SUDO_CMD} screen -dmS "${SESSION_NAME}" /bin/bash -c "cd '${SERVER_ROOT}'; ${EXECUTABLE_CMD}' nogui"
+		${SUDO_CMD} screen -dmS "${SESSION_NAME}" /bin/bash -c "cd '${SERVER_ROOT}'; ${EXECUTABLE_CMD}"
 		echo -e "\e[39;1m done\e[0m"
 	fi
 

--- a/minecraft-server/minecraftd@.service
+++ b/minecraft-server/minecraftd@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Minecraft Server
+After=local-fs.target network.target
+
+[Service]
+Type=forking
+Environment=NAME=%I
+Environment=GAME=%I
+ExecStart=/usr/bin/minecraftd start
+ExecStop=/usr/bin/minecraftd stop
+User=%I
+Group=%I
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
to launch cuberite with this script, do:
sudo GAME=cuberite NAME=cuberite ./minecraftd.sh start
